### PR TITLE
Implement dark mode for chat page with placeholder prompt

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,11 +1,21 @@
+"use client";
+
+import { useState } from "react";
 import ChatInput from "@/components/ChatInput";
 import MessageList from "@/components/MessageList";
 
 export default function ChatPage() {
+  const [messages, setMessages] = useState<string[]>([]);
+
+  const handleSend = (text: string) => {
+    if (text.trim() === "") return;
+    setMessages((prev) => [...prev, text]);
+  };
+
   return (
-    <div className="flex h-screen flex-col">
-      <MessageList />
-      <ChatInput />
+    <div className="flex h-screen flex-col bg-gray-900 text-white">
+      <MessageList messages={messages} />
+      <ChatInput onSend={handleSend} />
     </div>
   );
 }

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,14 +1,33 @@
-export default function ChatInput() {
+"use client";
+
+import { FormEvent, useState } from "react";
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+}
+
+export default function ChatInput({ onSend }: ChatInputProps) {
+  const [text, setText] = useState("");
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (text.trim() === "") return;
+    onSend(text);
+    setText("");
+  };
+
   return (
-    <form className="flex gap-2 p-4 border-t">
+    <form onSubmit={handleSubmit} className="flex gap-2 p-4 border-t bg-gray-800">
       <input
         type="text"
-        className="flex-1 rounded border px-3 py-2"
+        className="flex-1 rounded border px-3 py-2 bg-gray-700 text-white"
         placeholder="Type your message..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
       />
       <button
         type="submit"
-        className="rounded bg-black px-4 py-2 text-white"
+        className="rounded bg-blue-600 px-4 py-2 text-white"
       >
         Send
       </button>

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,7 +1,25 @@
-export default function MessageList() {
+"use client";
+
+interface MessageListProps {
+  messages: string[];
+}
+
+export default function MessageList({ messages }: MessageListProps) {
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-center text-gray-400">
+        Paste an article link, an article name or the article content.
+      </div>
+    );
+  }
+
   return (
     <div className="flex-1 overflow-y-auto p-4 space-y-2">
-      {/* Messages will appear here */}
+      {messages.map((msg, idx) => (
+        <div key={idx} className="rounded bg-gray-800 p-2">
+          {msg}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- make the chat page a client component and enable dark styling
- update ChatInput to submit messages and fit dark mode
- update MessageList to display prompt when empty and show messages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684176355ab08322958929362f220d61