### PR TITLE
Implement polished dark chat UI

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,11 +1,21 @@
+"use client";
+
+import { useState } from "react";
 import ChatInput from "@/components/ChatInput";
 import MessageList from "@/components/MessageList";
 
 export default function ChatPage() {
+  const [messages, setMessages] = useState<string[]>([]);
+
+  const handleSend = (text: string) => {
+    if (text.trim() === "") return;
+    setMessages((prev) => [...prev, text]);
+  };
+
   return (
-    <div className="flex h-screen flex-col">
-      <MessageList />
-      <ChatInput />
+    <div className="flex h-screen flex-col bg-neutral-950 text-white">
+      <MessageList messages={messages} />
+      <ChatInput onSend={handleSend} />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,8 +6,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-poppins);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Poppins } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const poppins = Poppins({
+  variable: "--font-poppins",
+  weight: ["400", "700"],
   subsets: ["latin"],
 });
 
@@ -24,9 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${poppins.variable} antialiased`}>
         {children}
       </body>
     </html>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,16 +1,37 @@
-export default function ChatInput() {
+"use client";
+
+import { FormEvent, useState } from "react";
+import { ArrowUpRight } from "lucide-react";
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+}
+
+export default function ChatInput({ onSend }: ChatInputProps) {
+  const [text, setText] = useState("");
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (text.trim() === "") return;
+    onSend(text);
+    setText("");
+  };
+
   return (
-    <form className="flex gap-2 p-4 border-t">
+    <form onSubmit={handleSubmit} className="flex gap-2 p-4 bg-gray-800">
       <input
         type="text"
-        className="flex-1 rounded border px-3 py-2"
+        className="flex-1 rounded-lg border border-gray-600 px-4 py-3 bg-gray-700 text-white"
         placeholder="Type your message..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
       />
       <button
         type="submit"
-        className="rounded bg-black px-4 py-2 text-white"
+        className="flex items-center justify-center rounded-full bg-blue-600 px-4 py-2 text-white"
       >
-        Send
+        <ArrowUpRight size={20} />
+        <span className="hidden sm:inline">Send</span>
       </button>
     </form>
   );

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,7 +1,25 @@
-export default function MessageList() {
+"use client";
+
+interface MessageListProps {
+  messages: string[];
+}
+
+export default function MessageList({ messages }: MessageListProps) {
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4 text-center text-white font-bold">
+        Paste an article link, an article name or the article content.
+      </div>
+    );
+  }
+
   return (
     <div className="flex-1 overflow-y-auto p-4 space-y-2">
-      {/* Messages will appear here */}
+      {messages.map((msg, idx) => (
+        <div key={idx} className="rounded bg-gray-800 p-2">
+          {msg}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- set Poppins as the global font
- tweak background color
- enlarge and round chat input with icon send button
- display bold placeholder text when no messages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684176355ab08322958929362f220d61