### PR TITLE
Implement initial AI chat and stats list

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -3,13 +3,29 @@
 import { useState } from "react";
 import ChatInput from "@/components/ChatInput";
 import MessageList from "@/components/MessageList";
+import { initAntiFakeAgent } from "@/lib/ai";
+
+interface Message {
+  text: string;
+  sender: "user" | "bot";
+}
 
 export default function ChatPage() {
-  const [messages, setMessages] = useState<string[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
 
-  const handleSend = (text: string) => {
+  const handleSend = async (text: string) => {
     if (text.trim() === "") return;
-    setMessages((prev) => [...prev, text]);
+    setMessages((prev) => [...prev, { text, sender: "user" }]);
+
+    try {
+      const apiKey = process.env.NEXT_PUBLIC_OPEN_AI_KEY;
+      if (!apiKey) return;
+      const agent = initAntiFakeAgent(apiKey);
+      const result = await agent.invoke({ input: text });
+      setMessages((prev) => [...prev, { text: result, sender: "bot" }]);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,12 +35,20 @@ export default function Home() {
           animate={{ opacity: 1 }}
           transition={{ duration: 0.7, delay: 0.4 }}
         >
-          <Link
-            href="/chat"
-            className="inline-flex items-center gap-2 rounded-full bg-white/90 px-6 py-3 text-lg font-medium text-black hover:bg-white"
-          >
-            Enter <FiArrowUpRight />
-          </Link>
+          <div className="flex justify-center gap-4">
+            <Link
+              href="/chat"
+              className="inline-flex items-center gap-2 rounded-full bg-white/90 px-6 py-3 text-lg font-medium text-black hover:bg-white"
+            >
+              Enter <FiArrowUpRight />
+            </Link>
+            <Link
+              href="/stats"
+              className="inline-flex items-center gap-2 rounded-full bg-white/90 px-6 py-3 text-lg font-medium text-black hover:bg-white"
+            >
+              Stats <FiArrowUpRight />
+            </Link>
+          </div>
         </motion.div>
       </div>
     </main>

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -12,6 +12,19 @@ import {
   Tooltip,
 } from "recharts";
 
+const networks = [
+  { name: "Channels TV", score: 78, image: "https://via.placeholder.com/60" },
+  { name: "AIT", score: 65, image: "https://via.placeholder.com/60" },
+  { name: "Punch", score: 72, image: "https://via.placeholder.com/60" },
+  { name: "Vanguard", score: 70, image: "https://via.placeholder.com/60" },
+  { name: "The Guardian Nigeria", score: 80, image: "https://via.placeholder.com/60" },
+  { name: "Sahara Reporters", score: 55, image: "https://via.placeholder.com/60" },
+  { name: "This Day", score: 68, image: "https://via.placeholder.com/60" },
+  { name: "Daily Trust", score: 75, image: "https://via.placeholder.com/60" },
+  { name: "The Nation", score: 73, image: "https://via.placeholder.com/60" },
+  { name: "NTA News", score: 60, image: "https://via.placeholder.com/60" },
+];
+
 const pieData = [
   { name: "Fake", value: 60 },
   { name: "Not Fake", value: 40 },
@@ -31,6 +44,26 @@ export default function StatsPage() {
   return (
     <div className="flex min-h-screen flex-col items-center bg-neutral-950 p-4 text-white space-y-8">
       <h1 className="text-3xl font-bold">Statistics</h1>
+      <div className="grid w-full max-w-xl grid-cols-1 gap-4">
+        {networks.map((nw, idx) => (
+          <div
+            key={idx}
+            className="flex items-center justify-between rounded-lg bg-gray-800 p-4"
+          >
+            <div className="flex items-center gap-4">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={nw.image} alt={nw.name} className="h-12 w-12 rounded-full" />
+              <span>{nw.name}</span>
+            </div>
+            <div
+              className="rounded px-3 py-1 font-semibold text-black"
+              style={{ backgroundColor: `hsl(${nw.score * 1.2},70%,50%)` }}
+            >
+              {nw.score}
+            </div>
+          </div>
+        ))}
+      </div>
       <div className="w-full max-w-xl">
         <h2 className="mb-4 text-lg font-semibold">Fake vs Not-Fake News</h2>
         <ResponsiveContainer width="100%" height={300}>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -4,16 +4,16 @@ import { FormEvent, useState } from "react";
 import { FiArrowUpRight } from "react-icons/fi";
 
 interface ChatInputProps {
-  onSend: (message: string) => void;
+  onSend: (message: string) => Promise<void> | void;
 }
 
 export default function ChatInput({ onSend }: ChatInputProps) {
   const [text, setText] = useState("");
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (text.trim() === "") return;
-    onSend(text);
+    await onSend(text);
     setText("");
   };
 

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,7 +1,12 @@
 "use client";
 
+interface Message {
+  text: string;
+  sender: "user" | "bot";
+}
+
 interface MessageListProps {
-  messages: string[];
+  messages: Message[];
 }
 
 export default function MessageList({ messages }: MessageListProps) {
@@ -18,8 +23,13 @@ export default function MessageList({ messages }: MessageListProps) {
   return (
     <div className="flex-1 overflow-y-auto space-y-2 p-4">
       {messages.map((msg, idx) => (
-        <div key={idx} className="rounded-lg bg-gray-800 px-4 py-2">
-          {msg}
+        <div
+          key={idx}
+          className={`rounded-lg px-4 py-2 max-w-[80%] ${
+            msg.sender === "user" ? "ml-auto bg-blue-600" : "bg-gray-800"
+          }`}
+        >
+          {msg.text}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- add Stats button on home page
- integrate anti-fake agent in chat UI
- support user/bot message rendering
- allow async chat input handler
- display Nigerian news network scores on stats page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841931d645083228caebf2b9c9ba356