### PR TITLE
UI improvements and stats enhancements

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -29,9 +29,11 @@ export default function ChatPage() {
   };
 
   return (
-    <div className="flex h-screen flex-col bg-neutral-950 text-white">
-      <MessageList messages={messages} />
-      <ChatInput onSend={handleSend} />
+    <div className="flex h-screen flex-col items-center bg-neutral-950 text-white">
+      <div className="flex h-full w-full max-w-2xl flex-col">
+        <MessageList messages={messages} />
+        <ChatInput onSend={handleSend} />
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,13 +38,13 @@ export default function Home() {
           <div className="flex flex-col sm:flex-row justify-center gap-4">
             <Link
               href="/chat"
-              className="inline-flex items-center gap-2 rounded-full bg-white/90 px-6 py-3 text-lg font-medium text-black hover:bg-white"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-white/90 px-6 py-3 text-lg font-medium text-black hover:bg-white sm:w-auto"
             >
               Enter <FiArrowUpRight />
             </Link>
             <Link
               href="/stats"
-              className="mt-2 sm:mt-0 inline-flex items-center gap-2 rounded-full border border-white/70 px-6 py-3 text-lg font-medium text-white hover:bg-white/10"
+              className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/70 px-6 py-3 text-lg font-medium text-white hover:bg-white/10 sm:mt-0 sm:w-auto"
             >
               Stats <FiArrowUpRight />
             </Link>

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -13,16 +13,16 @@ import {
 } from "recharts";
 
 const networks = [
-  { name: "Channels TV", score: 78, image: "https://logo.clearbit.com/channelstv.com" },
-  { name: "AIT", score: 65, image: "https://logo.clearbit.com/ait.live" },
-  { name: "Punch", score: 72, image: "https://logo.clearbit.com/punchng.com" },
-  { name: "Vanguard", score: 70, image: "https://logo.clearbit.com/vanguardngr.com" },
-  { name: "The Guardian Nigeria", score: 80, image: "https://logo.clearbit.com/guardian.ng" },
-  { name: "Sahara Reporters", score: 55, image: "https://logo.clearbit.com/saharareporters.com" },
-  { name: "This Day", score: 68, image: "https://logo.clearbit.com/thisdaylive.com" },
-  { name: "Daily Trust", score: 75, image: "https://logo.clearbit.com/dailytrust.com" },
-  { name: "The Nation", score: 73, image: "https://logo.clearbit.com/thenationonlineng.net" },
-  { name: "NTA News", score: 60, image: "https://logo.clearbit.com/nta.ng" },
+  { name: "Channels TV", score: 78, image: "https://logo.clearbit.com/channelstv.com", link: "https://channelstv.com" },
+  { name: "AIT", score: 65, image: "https://logo.clearbit.com/ait.live", link: "https://ait.live" },
+  { name: "Punch", score: 72, image: "https://logo.clearbit.com/punchng.com", link: "https://punchng.com" },
+  { name: "Vanguard", score: 70, image: "https://logo.clearbit.com/vanguardngr.com", link: "https://vanguardngr.com" },
+  { name: "The Guardian Nigeria", score: 80, image: "https://logo.clearbit.com/guardian.ng", link: "https://guardian.ng" },
+  { name: "Sahara Reporters", score: 55, image: "https://logo.clearbit.com/saharareporters.com", link: "https://saharareporters.com" },
+  { name: "This Day", score: 68, image: "https://logo.clearbit.com/thisdaylive.com", link: "https://thisdaylive.com" },
+  { name: "Daily Trust", score: 75, image: "https://logo.clearbit.com/dailytrust.com", link: "https://dailytrust.com" },
+  { name: "The Nation", score: 73, image: "https://logo.clearbit.com/thenationonlineng.net", link: "https://thenationonlineng.net" },
+  { name: "NTA News", score: 60, image: "https://logo.clearbit.com/nta.ng", link: "https://nta.ng" },
 ];
 
 const pieData = [
@@ -44,6 +44,7 @@ export default function StatsPage() {
   return (
     <div className="flex min-h-screen flex-col items-center bg-neutral-950 p-4 text-white space-y-8">
       <h1 className="text-3xl font-bold">Statistics</h1>
+      <h2 className="text-lg font-semibold">News Channels &amp; Credibility Scores</h2>
       <div className="grid w-full max-w-xl grid-cols-1 gap-4">
         {networks.map((nw, idx) => (
           <div
@@ -53,7 +54,14 @@ export default function StatsPage() {
             <div className="flex items-center gap-4">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={nw.image} alt={nw.name} className="h-12 w-12 rounded-full" />
-              <span>{nw.name}</span>
+              <a
+                href={nw.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:underline"
+              >
+                {nw.name}
+              </a>
             </div>
             <div
               className="rounded px-3 py-1 font-semibold text-black"

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -18,7 +18,7 @@ export default function ChatInput({ onSend }: ChatInputProps) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex gap-2 p-4 bg-gray-800">
+    <form onSubmit={handleSubmit} className="flex w-full gap-2 p-4 bg-gray-800">
       <input
         type="text"
         className="flex-1 rounded-full border border-gray-600 px-4 py-3 bg-gray-700 text-white"

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { FiCpu, FiUser } from "react-icons/fi";
+
 interface Message {
   text: string;
   sender: "user" | "bot";
@@ -13,7 +15,7 @@ export default function MessageList({ messages }: MessageListProps) {
   if (messages.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center p-4">
-        <div className="rounded-full border border-gray-600 bg-gray-800/70 px-6 py-3 text-center text-gray-300 font-medium">
+        <div className="rounded-md border border-gray-600 bg-gray-800/70 px-8 py-4 text-center text-gray-300 font-medium">
           Paste an article link, an article name or the article content.
         </div>
       </div>
@@ -21,15 +23,29 @@ export default function MessageList({ messages }: MessageListProps) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto space-y-2 p-4">
+    <div className="flex-1 w-full overflow-y-auto space-y-4 p-4">
       {messages.map((msg, idx) => (
         <div
           key={idx}
-          className={`rounded-lg px-4 py-2 max-w-[80%] ${
-            msg.sender === "user" ? "ml-auto bg-blue-600" : "bg-gray-800"
-          }`}
+          className={`flex gap-2 ${msg.sender === "user" ? "justify-end" : ""}`}
         >
-          {msg.text}
+          {msg.sender === "bot" && (
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-700">
+              <FiCpu className="text-white" />
+            </div>
+          )}
+          <div
+            className={`order-1 rounded-lg px-4 py-2 max-w-[80%] ${
+              msg.sender === "user" ? "bg-blue-600 text-white" : "bg-gray-800 text-white"
+            }`}
+          >
+            {msg.text}
+          </div>
+          {msg.sender === "user" && (
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600">
+              <FiUser className="text-white" />
+            </div>
+          )}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- center landing page buttons and make them full width on mobile
- restrict chat layout width and add avatars for messages
- improve placeholder and padding
- add title and clickable links on stats page

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6841a21f68f08322bde9e4dad122e1ca