### PR TITLE
Fix chat scrollbars

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -76,13 +76,13 @@ export default function ChatPage() {
   };
 
   return (
-    <div className="flex h-screen flex-col items-center bg-neutral-950 text-white overflow-hidden">
+    <div className="flex min-h-screen flex-col items-center bg-neutral-950 text-white">
       <div className="w-full p-4">
         <Link href="/" className="flex items-center gap-1 text-white hover:underline">
           <FiArrowLeft /> Home
         </Link>
       </div>
-      <div className="flex h-full w-full max-w-2xl flex-col">
+      <div className="flex w-full max-w-2xl flex-col">
         <MessageList messages={messages} />
         <ChatInput onSend={handleSend} />
       </div>

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -36,7 +36,7 @@ export default function MessageList({ messages }: MessageListProps) {
   };
 
   return (
-    <div className="flex-1 w-full overflow-y-auto space-y-4 p-4">
+    <div className="flex-1 w-full space-y-4 p-4">
       {messages.map((msg, idx) => (
         <div
           key={idx}


### PR DESCRIPTION
## Summary
- allow Chat page to grow beyond viewport so the browser scrollbar works
- remove the internal scroll from the message list

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842be4e021c8322b0002c6d5dd928eb