### PR TITLE
Improve input UI and move parsing server-side

### DIFF
--- a/src/app/api/process/route.ts
+++ b/src/app/api/process/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchArticleText } from "@/lib/article";
+import { findCredibleSources } from "@/lib/googleSearch";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { input } = await req.json();
+    let content = String(input || "").trim();
+    if (/^https?:\/\//i.test(content)) {
+      content = await fetchArticleText(content);
+    }
+    const sources = await findCredibleSources(content.slice(0, 120));
+    return NextResponse.json({ content, sources });
+  } catch (err) {
+    console.error("process error", err);
+    return NextResponse.json({ content: "", sources: [] });
+  }
+}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -18,7 +18,6 @@ export default function MessageList({ messages }: MessageListProps) {
     return (
       <div className="flex flex-1 items-center justify-center p-4">
         <div className="rounded-md border border-gray-600 bg-gray-800/70 px-8 py-4 text-center text-gray-300 font-medium space-y-2">
-          <p>Paste an article link, an article name, the article content, or upload a picture with text of a news article.</p>
           <p className="text-sm">Example prompts:</p>
           <p className="text-sm">"Is this Guardian article fake?"</p>
           <p className="text-sm">"Check if this story is credible."</p>
@@ -52,8 +51,8 @@ export default function MessageList({ messages }: MessageListProps) {
               msg.sender === "user"
                 ? "bg-blue-600 text-white"
                 : msg.error
-                ? "bg-red-900 text-red-200 border border-red-400"
-                : "bg-gray-800 text-white"
+                  ? "bg-red-900 text-red-200 border border-red-400"
+                  : "bg-gray-800 text-white"
             }`}
           >
             {msg.loading ? (


### PR DESCRIPTION
## Summary
- keep chat input fixed to the bottom and show vertical/horizontal suggestions
- add paste and upload quick actions using icons
- remove confusing text from the empty message list
- create server route to parse article links and search Google
- use the new process route in the chat page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684378c515ec8322a0f5f0e085d1ba26