### PR TITLE
Improve chat UI suggestions and AI output

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -67,21 +67,27 @@ export default function ChatInput({ onSend }: ChatInputProps) {
           <button
             type="button"
             onClick={handlePasteClick}
-            className="flex items-center gap-1 rounded-full bg-gray-700 px-3 py-2 text-white"
+            className="relative flex items-center gap-2 rounded-lg bg-gray-700 px-3 py-2 text-left text-white"
           >
-            <Lightbulb className="h-4 w-4" />
-            <FiClipboard className="h-4 w-4" />
-            <span>Paste</span>
+            <FiClipboard className="h-6 w-6" />
+            <div className="flex flex-col">
+              <span className="font-bold">Paste</span>
+              <span className="text-xs text-gray-300">Insert text from your clipboard.</span>
+            </div>
+            <Lightbulb className="absolute right-1 top-1 h-4 w-4 text-yellow-300" />
           </button>
         )}
         <button
           type="button"
           onClick={() => fileRef.current?.click()}
-          className="flex items-center gap-1 rounded-full bg-gray-700 px-3 py-2 text-white"
+          className="relative flex items-center gap-2 rounded-lg bg-gray-700 px-3 py-2 text-left text-white"
         >
-          <Lightbulb className="h-4 w-4" />
-          <FiImage className="h-4 w-4" />
-          <span>Upload image</span>
+          <FiImage className="h-6 w-6" />
+          <div className="flex flex-col">
+            <span className="font-bold">Upload Image</span>
+            <span className="text-xs text-gray-300">Snap or choose a photo to analyse.</span>
+          </div>
+          <Lightbulb className="absolute right-1 top-1 h-4 w-4 text-yellow-300" />
         </button>
       </div>
       <input

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -37,7 +37,7 @@ export function initAntiFakeAgent(
       'You are anti-fake bot. Analyse the provided news content and decide if it feels fake. ' +
       "You should reply to greetings and questions with a short and friendly response." +
         'If the text is incoherent or too short, reply "Content is incoherent. No score." ' +
-        'Otherwise reply in Markdown with the Fake score out of 100 on the first line it becomes higher the more likely a news is to be fake and lower the more genuine the news feels i.e Fake Score [Score]/100, the score formatted in **bold**. ' +
+        'Otherwise reply in Markdown with the Fake score on the first line. It becomes higher the more likely the news is to be fake and lower the more genuine it feels. Use the format Fake Score: **[Score]%**. ' +
         'Under the score outline the reasons in bullet points. Highlight any false statements by surrounding them with **.'
     ),
     HumanMessagePromptTemplate.fromTemplate('{input}'),


### PR DESCRIPTION
## Summary
- update suggestion layout in `ChatInput`
- instruct AI to output `Fake Score: [Score]%`

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68437e106750832286515ccf46e241b9