### PR TITLE
Improve chat suggestions UI

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -67,27 +67,37 @@ export default function ChatInput({ onSend }: ChatInputProps) {
           <button
             type="button"
             onClick={handlePasteClick}
-            className="relative flex items-center gap-2 rounded-lg bg-gray-700 px-3 py-2 text-left text-white"
+            className="relative flex items-center gap-2 rounded-xl border border-white bg-neutral-800 px-4 py-3 text-left text-white"
           >
             <FiClipboard className="h-6 w-6" />
             <div className="flex flex-col">
               <span className="font-bold">Paste</span>
-              <span className="text-xs text-gray-300">Insert text from your clipboard.</span>
+              <span className="text-xs text-gray-300">
+                Insert text from your clipboard for quick analysis.<br/>
+                Start chatting instantly.
+              </span>
             </div>
-            <Lightbulb className="absolute right-1 top-1 h-4 w-4 text-yellow-300" />
+            <div className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-blue-950">
+              <Lightbulb className="h-3 w-3 text-blue-300" />
+            </div>
           </button>
         )}
         <button
           type="button"
           onClick={() => fileRef.current?.click()}
-          className="relative flex items-center gap-2 rounded-lg bg-gray-700 px-3 py-2 text-left text-white"
+          className="relative flex items-center gap-2 rounded-xl border border-white bg-neutral-800 px-4 py-3 text-left text-white"
         >
           <FiImage className="h-6 w-6" />
           <div className="flex flex-col">
             <span className="font-bold">Upload Image</span>
-            <span className="text-xs text-gray-300">Snap or choose a photo to analyse.</span>
+            <span className="text-xs text-gray-300">
+              Snap or choose a photo to analyse for text extraction.<br/>
+              Get insights in seconds.
+            </span>
           </div>
-          <Lightbulb className="absolute right-1 top-1 h-4 w-4 text-yellow-300" />
+          <div className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-blue-950">
+            <Lightbulb className="h-3 w-3 text-blue-300" />
+          </div>
         </button>
       </div>
       <input

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -17,10 +17,12 @@ export default function MessageList({ messages }: MessageListProps) {
   if (messages.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center p-4">
-        <div className="rounded-md border border-gray-600 bg-gray-800/70 px-8 py-4 text-center text-gray-300 font-medium space-y-2">
-          <p className="text-sm">Example prompts:</p>
-          <p className="text-sm">"Is this Guardian article fake?"</p>
-          <p className="text-sm">"Check if this story is credible."</p>
+        <div className="space-y-2 rounded-md border border-gray-600 bg-neutral-900 px-8 py-4 text-gray-300">
+          <p className="text-sm font-medium">Example prompts:</p>
+          <ul className="list-inside list-disc space-y-1 text-sm">
+            <li>"Is this Guardian article fake?"</li>
+            <li>"Check if this story is credible."</li>
+          </ul>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- tweak ChatInput suggestion buttons to be darker with outlines
- show line breaks in suggestion descriptions
- make the helper bulb dark blue on a circular background
- display example prompts in a bullet list with a dark background

## Testing
- `pnpm install --frozen-lockfile`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68438243baa48322bd70efc77fc92f48