### PR TITLE
Improve chat input layout and guidance

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -82,7 +82,9 @@ export default function ChatPage() {
           <FiArrowLeft /> Home
         </Link>
       </div>
-      <div className="flex w-full max-w-2xl flex-col pb-32">
+      <div
+        className={`flex w-full max-w-2xl flex-col ${messages.length ? 'pb-48' : 'pb-32'}`}
+      >
         <MessageList messages={messages} />
         <ChatInput onSend={handleSend} />
       </div>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -2,7 +2,6 @@
 
 import { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react";
 import { FiArrowUpRight, FiImage, FiClipboard } from "react-icons/fi";
-import { Lightbulb } from "lucide-react";
 
 interface ChatInputProps {
   onSend: (message: string) => Promise<void> | void;
@@ -67,7 +66,7 @@ export default function ChatInput({ onSend }: ChatInputProps) {
           <button
             type="button"
             onClick={handlePasteClick}
-            className="relative flex items-center gap-2 rounded-xl border border-white bg-neutral-800 px-4 py-3 text-left text-white"
+            className="relative flex items-center gap-2 rounded-xl border border-white bg-neutral-900 px-4 py-3 text-left text-white"
           >
             <FiClipboard className="h-6 w-6" />
             <div className="flex flex-col">
@@ -77,15 +76,12 @@ export default function ChatInput({ onSend }: ChatInputProps) {
                 Start chatting instantly.
               </span>
             </div>
-            <div className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-blue-950">
-              <Lightbulb className="h-3 w-3 text-blue-300" />
-            </div>
           </button>
         )}
         <button
           type="button"
           onClick={() => fileRef.current?.click()}
-          className="relative flex items-center gap-2 rounded-xl border border-white bg-neutral-800 px-4 py-3 text-left text-white"
+          className="relative flex items-center gap-2 rounded-xl border border-white bg-neutral-900 px-4 py-3 text-left text-white"
         >
           <FiImage className="h-6 w-6" />
           <div className="flex flex-col">
@@ -95,14 +91,11 @@ export default function ChatInput({ onSend }: ChatInputProps) {
               Get insights in seconds.
             </span>
           </div>
-          <div className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-blue-950">
-            <Lightbulb className="h-3 w-3 text-blue-300" />
-          </div>
         </button>
       </div>
       <input
         type="text"
-        className="flex-1 rounded-full border border-gray-600 bg-gray-700 px-4 py-3 text-white"
+        className="flex-1 rounded-full border border-gray-600 bg-neutral-900 px-4 py-3 text-white"
         placeholder="Type your message..."
         value={text}
         onChange={(e) => setText(e.target.value)}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -17,12 +17,13 @@ export default function MessageList({ messages }: MessageListProps) {
   if (messages.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center p-4">
-        <div className="space-y-2 rounded-md border border-gray-600 bg-neutral-900 px-8 py-4 text-gray-300">
-          <p className="text-sm font-medium">Example prompts:</p>
-          <ul className="list-inside list-disc space-y-1 text-sm">
-            <li>"Is this Guardian article fake?"</li>
-            <li>"Check if this story is credible."</li>
-          </ul>
+        <div className="flex gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-700">
+            <FiCpu className="text-white" />
+          </div>
+          <div className="rounded-lg bg-gray-800 px-4 py-2 text-white">
+            Type or paste a message to begin.
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- tweak chat page padding based on message count
- darken suggestion buttons and input background
- remove suggestion lightbulb icons
- replace example prompts with a bot instruction

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843854144008322b1d05fbe671a8049