### PR TITLE
Add genuity scoring and tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_OPENAI_KEY=***
+MONGODB_URI=mongodb://localhost:27017/antifake

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "recharts": "^2.15.3",
-    "tailwind-merge": "^3.3.0"
+    "tailwind-merge": "^3.3.0",
+    "mongoose": "^8.0.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       lucide-react:
         specifier: ^0.513.0
         version: 0.513.0(react@19.1.0)
+      mongoose:
+        specifier: ^8.0.2
+        version: 8.15.2
       next:
         specifier: 15.3.3
         version: 15.3.3(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -414,6 +417,9 @@ packages:
     resolution: {integrity: sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==}
     engines: {node: '>=18'}
 
+  '@mongodb-js/saslprep@1.3.0':
+    resolution: {integrity: sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==}
+
   '@mozilla/readability@0.4.4':
     resolution: {integrity: sha512-MCgZyANpJ6msfvVMi6+A0UAsvZj//4OHREYUB9f2087uXHVoU+H+SWhuihvb1beKpM323bReQPRio0WNk2+V6g==}
     engines: {node: '>=14.0.0'}
@@ -650,6 +656,12 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@11.0.5':
+    resolution: {integrity: sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -764,6 +776,10 @@ packages:
     resolution: {integrity: sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bson@6.10.4:
+    resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
+    engines: {node: '>=16.20.1'}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -1547,6 +1563,10 @@ packages:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
 
+  kareem@2.6.3:
+    resolution: {integrity: sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==}
+    engines: {node: '>=12.0.0'}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -1728,6 +1748,9 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -1792,11 +1815,53 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mongodb-connection-string-url@3.0.2:
+    resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
+
+  mongodb@6.16.0:
+    resolution: {integrity: sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==}
+    engines: {node: '>=16.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.1.0 || ^2.0.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
+      snappy: ^7.2.2
+      socks: ^2.7.1
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongoose@8.15.2:
+    resolution: {integrity: sha512-GLwghI2dS/n5BTBljspF4+FsCEBeHgnMQyX8GloYkLkl+MKljKkjcP9DhLr47Yod2RO1RCr4vZ3evUZAyuoILw==}
+    engines: {node: '>=16.20.1'}
+
   motion-dom@12.16.0:
     resolution: {integrity: sha512-Z2nGwWrrdH4egLEtgYMCEN4V2qQt1qxlKy/uV7w691ztyA41Q5Rbn0KNGbsNVDZr9E8PD2IOQ3hSccRnB6xWzw==}
 
   motion-utils@12.12.1:
     resolution: {integrity: sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==}
+
+  mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+
+  mquery@5.0.0:
+    resolution: {integrity: sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==}
+    engines: {node: '>=14.0.0'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2218,6 +2283,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  sift@17.1.3:
+    resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2241,6 +2309,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
   sshpk@1.18.0:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
@@ -2349,6 +2420,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-morph@18.0.0:
     resolution: {integrity: sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==}
@@ -2467,12 +2542,20 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
@@ -2900,6 +2983,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mongodb-js/saslprep@1.3.0':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
   '@mozilla/readability@0.4.4': {}
 
   '@mswjs/interceptors@0.38.7':
@@ -3098,6 +3185,12 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@11.0.5':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -3229,6 +3322,8 @@ snapshots:
       electron-to-chromium: 1.5.165
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
+
+  bson@6.10.4: {}
 
   buffer@6.0.3:
     dependencies:
@@ -4008,6 +4103,8 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
+  kareem@2.6.3: {}
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
@@ -4135,6 +4232,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memory-pager@1.5.0: {}
+
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
@@ -4178,11 +4277,49 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
+  mongodb-connection-string-url@3.0.2:
+    dependencies:
+      '@types/whatwg-url': 11.0.5
+      whatwg-url: 14.2.0
+
+  mongodb@6.16.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.3.0
+      bson: 6.10.4
+      mongodb-connection-string-url: 3.0.2
+
+  mongoose@8.15.2:
+    dependencies:
+      bson: 6.10.4
+      kareem: 2.6.3
+      mongodb: 6.16.0
+      mpath: 0.9.0
+      mquery: 5.0.0
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+      - supports-color
+
   motion-dom@12.16.0:
     dependencies:
       motion-utils: 12.12.1
 
   motion-utils@12.12.1: {}
+
+  mpath@0.9.0: {}
+
+  mquery@5.0.0:
+    dependencies:
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   ms@2.1.3: {}
 
@@ -4717,6 +4854,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  sift@17.1.3: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -4733,6 +4872,10 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
 
   sshpk@1.18.0:
     dependencies:
@@ -4837,6 +4980,10 @@ snapshots:
       url-parse: 1.5.10
 
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-morph@18.0.0:
     dependencies:
@@ -4945,11 +5092,18 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectDB, News } from '@/lib/db'
+
+export async function POST(req: NextRequest) {
+  await connectDB()
+  const { source, score, text } = await req.json()
+  try {
+    const doc = await News.create({ source, score, text })
+    return NextResponse.json({ id: doc.id })
+  } catch (err: any) {
+    console.error('save error', err)
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}
+
+export async function GET() {
+  await connectDB()
+  const records = await News.aggregate([
+    { $group: { _id: '$source', avgScore: { $avg: '$score' }, count: { $sum: 1 } } },
+    { $project: { _id: 0, source: '$_id', avgScore: 1, count: 1 } },
+    { $sort: { avgScore: -1 } },
+  ])
+  return NextResponse.json(records)
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -7,6 +7,7 @@ import ChatInput from "@/components/ChatInput";
 import MessageList from "@/components/MessageList";
 import { initAntiFakeAgent } from "@/lib/ai";
 
+
 interface Message {
   text: string;
   sender: "user" | "bot";
@@ -58,6 +59,20 @@ export default function ChatPage() {
         msgs[msgs.length - 1] = { text: result, sender: "bot" };
         return msgs;
       });
+
+      const match = /Genuine Score:\s*\*\*(\d+(?:\.\d+)?)%\*/i.exec(result);
+      if (match) {
+        const score = parseFloat(match[1]);
+        fetch("/api/news", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            source: sources[0] || "unknown",
+            score,
+            text: content,
+          }),
+        }).catch((err) => console.error("save error", err));
+      }
     } catch (err: any) {
       console.error(err);
       setMessages((prev) => {

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -5,33 +5,19 @@ import {
   Pie,
   Cell,
   ResponsiveContainer,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
   Tooltip,
 } from "recharts";
 import Link from "next/link";
 import { FiArrowLeft } from "react-icons/fi";
+import { useEffect, useState } from "react";
 
-const networks = [
-  { name: "Channels TV", score: 78, image: "https://logo.clearbit.com/channelstv.com", link: "https://channelstv.com" },
-  { name: "AIT", score: 65, image: "https://logo.clearbit.com/ait.live", link: "https://ait.live" },
-  { name: "Punch", score: 72, image: "https://logo.clearbit.com/punchng.com", link: "https://punchng.com" },
-  { name: "Vanguard", score: 70, image: "https://logo.clearbit.com/vanguardngr.com", link: "https://vanguardngr.com" },
-  { name: "The Guardian Nigeria", score: 80, image: "https://logo.clearbit.com/guardian.ng", link: "https://guardian.ng" },
-  { name: "Sahara Reporters", score: 55, image: "https://logo.clearbit.com/saharareporters.com", link: "https://saharareporters.com" },
-  { name: "This Day", score: 68, image: "https://logo.clearbit.com/thisdaylive.com", link: "https://thisdaylive.com" },
-  { name: "Daily Trust", score: 75, image: "https://logo.clearbit.com/dailytrust.com", link: "https://dailytrust.com" },
-  { name: "The Nation", score: 73, image: "https://logo.clearbit.com/thenationonlineng.net", link: "https://thenationonlineng.net" },
-  { name: "NTA News", score: 60, image: "https://logo.clearbit.com/nta.ng", link: "https://nta.ng" },
-];
+interface RecordData {
+  source: string;
+  avgScore: number;
+  count: number;
+}
 
-const pieData = [
-  { name: "Fake", value: 60 },
-  { name: "Not Fake", value: 40 },
-];
-
+const COLORS = ["#10B981", "#EF4444"];
 const barData = [
   { name: "Mon", checked: 10 },
   { name: "Tue", checked: 15 },
@@ -40,9 +26,33 @@ const barData = [
   { name: "Fri", checked: 5 },
 ];
 
-const COLORS = ["#EF4444", "#10B981"];
-
 export default function StatsPage() {
+  const [records, setRecords] = useState<RecordData[]>([]);
+
+  useEffect(() => {
+    fetch('/api/news')
+      .then((r) => r.json())
+      .then(setRecords)
+      .catch((err) => console.error('stats fetch error', err));
+  }, []);
+
+  const networks = records.map((r) => ({
+    name: r.source,
+    score: Math.round(r.avgScore),
+    image: `https://logo.clearbit.com/${r.source}`,
+    link: `https://${r.source}`,
+  }));
+  const pieData = [
+    {
+      name: 'Genuine',
+      value: records.reduce((a, r) => a + (r.avgScore >= 50 ? r.count : 0), 0),
+    },
+    {
+      name: 'Not Genuine',
+      value: records.reduce((a, r) => a + (r.avgScore < 50 ? r.count : 0), 0),
+    },
+  ];
+
   return (
     <div className="flex min-h-screen flex-col items-center bg-neutral-950 p-4 text-white space-y-8">
       <div className="w-full">
@@ -80,7 +90,7 @@ export default function StatsPage() {
         ))}
       </div>
       <div className="w-full max-w-xl">
-        <h2 className="mb-4 text-lg font-semibold">Fake vs Not-Fake News</h2>
+        <h2 className="mb-4 text-lg font-semibold">Genuine vs Not-Genuine News</h2>
         <ResponsiveContainer width="100%" height={300}>
           <PieChart>
             <Pie data={pieData} dataKey="value" nameKey="name" outerRadius={100} label>

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -34,11 +34,13 @@ export function initAntiFakeAgent(
 
   const prompt = ChatPromptTemplate.fromMessages([
     SystemMessagePromptTemplate.fromTemplate(
-      'You are anti-fake bot. Analyse the provided news content and decide if it feels fake. ' +
-      "You should reply to greetings and questions with a short and friendly response." +
-        'If the text is incoherent or too short, reply "Content is incoherent. No score." ' +
-        'Otherwise reply in Markdown with the Fake score on the first line. It becomes higher the more likely the news is to be fake and lower the more genuine it feels. Use the format Fake Score: **[Score]%**. ' +
-        'Under the score outline the reasons in bullet points. Highlight any false statements by surrounding them with **.'
+      'You are anti-fake bot. Analyse the provided news content and decide how genuine it is.' +
+        ' Do not treat publication dates in the future as evidence the news is fake.' +
+        " You should reply to greetings and questions with a short and friendly response." +
+        ' If the text is incoherent or too short, reply "Content is incoherent. No score." ' +
+        ' Otherwise evaluate genuity using these factors: Readability score, average sentence length, lexical diversity, clickbait terms, sentiment polarity and subjectivity, named-entity consistency, domain age, source reputation, comment-to-share ratio, cascade depth and breadth, contradiction with known facts, perplexity under a reliable news model, similarity to reputable articles, stance agreement with trusted sources, temporal novelty, topic coherence, and engagement sentiment mix. ' +
+        ' Reply in Markdown with the Genuine score on the first line. It becomes higher the more likely the news is real. Use the format Genuine Score: **[Score]%**. ' +
+        ' Under the score outline the reasons in bullet points. Highlight any false statements by surrounding them with **.'
     ),
     HumanMessagePromptTemplate.fromTemplate('{input}'),
   ])

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose'
+
+const MONGODB_URI =
+  process.env.MONGODB_URI || 'mongodb://localhost:27017/antifake'
+
+let cached = (global as any).mongoose
+if (!cached) {
+  cached = (global as any).mongoose = { conn: null, promise: null }
+}
+
+export async function connectDB() {
+  if (cached.conn) return cached.conn
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(MONGODB_URI, { dbName: 'antifake' }).then(m => m)
+  }
+  cached.conn = await cached.promise
+  return cached.conn
+}
+
+const newsSchema = new mongoose.Schema({
+  source: String,
+  score: Number,
+  text: String,
+}, { timestamps: true })
+
+export const News = mongoose.models.News || mongoose.model('News', newsSchema)


### PR DESCRIPTION
## Summary
- update AI prompt to produce `Genuine Score` and ignore future dates
- store scores in MongoDB via new API endpoints
- record scores from the chat page
- fetch dynamic stats from MongoDB on the stats page
- add mongoose dependency and sample `MONGODB_URI`

## Testing
- `pnpm install`
- `npm run lint` *(fails: requires setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c7a607e908322be7914fa0edaf194