### PR TITLE
Improve source extraction for saved news

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -6,6 +6,7 @@ import { FiArrowLeft } from "react-icons/fi";
 import ChatInput from "@/components/ChatInput";
 import MessageList from "@/components/MessageList";
 import { initAntiFakeAgent } from "@/lib/ai";
+import { getBaseDomain } from "@/lib/utils";
 
 
 interface Message {
@@ -28,6 +29,7 @@ export default function ChatPage() {
 
     try {
       const apiKey = process.env.NEXT_PUBLIC_OPENAI_KEY;
+      const baseDomain = getBaseDomain(text);
       if (!apiKey) {
         setMessages((prev) => [
           ...prev,
@@ -67,7 +69,7 @@ export default function ChatPage() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            source: sources[0] || "unknown",
+            source: baseDomain || sources[0] || "unknown",
             score,
             text: content,
           }),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getBaseDomain(str: string): string | null {
+  try {
+    const url = new URL(str.trim())
+    return url.hostname.replace(/^www\./, '')
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- record the base domain from URLs when saving a news item
- add utility `getBaseDomain` for extracting domain names

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684c7ecf58388322b693ab2021c33dda